### PR TITLE
Allow users to opt out of their messages getting relayed to IRC, refactored preferences

### DIFF
--- a/plugins/ircbridge/ircbridge.js
+++ b/plugins/ircbridge/ircbridge.js
@@ -36,16 +36,12 @@ handlers.enable = function(cb) {
         storage.telegramUserPreferences = storage.telegramUserPreferences || {};
 
         // Load legacy config
-        if (storage.telegramColors) {
-            object.keys(storage.telegramColors).forEach(
-                user => setUserPreference(user, PREFERENCES_KEY_COLOUR, storage.telegramColors[user]));
-            storage.telegramColors = {};
-        }
-        if (storage.telegramAliases) {
-            object.keys(storage.telegramAliases).forEach(
-                user => setUserPreference(user, PREFERENCES_KEY_ALIAS, storage.telegramAliases[user]));
-            storage.telegramAliases = {};
-        }
+        object.keys(storage.telegramColors || {}).forEach(
+            user => setUserPreference(user, PREFERENCES_KEY_COLOUR, storage.telegramColors[user]));
+        storage.telegramColors = {};
+        object.keys(storage.telegramAliases || {}).forEach(
+            user => setUserPreference(user, PREFERENCES_KEY_ALIAS, storage.telegramAliases[user]));
+        storage.telegramAliases = {};
         
         return Promise.try(function() {
             Object.keys(config.servers).forEach(function(serverName) {

--- a/plugins/ircbridge/package.json
+++ b/plugins/ircbridge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ircbridge",
-    "version": "1.0.0",
+    "version": "0.2.0",
     "main": "ircbridge.js",
     "dependencies": {
         "irc": "^0.4.1"

--- a/plugins/ircbridge/package.json
+++ b/plugins/ircbridge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ircbridge",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "main": "ircbridge.js",
     "dependencies": {
         "irc": "^0.4.1"


### PR DESCRIPTION
Some of us don't want all of our messages in a group chat to be relayed to IRC. This adds an option for individual users to opt out of their messages being forwarded, so that they can enable and disable this behaviour whenever they so desire.

@thumbnail ^^