### PR TITLE
Don't try to run setup wizard if `local.js` config file exists

### DIFF
--- a/setupwizard.js
+++ b/setupwizard.js
@@ -15,7 +15,7 @@ function isConfigCustomized() {
     return _.some(fs.readdirSync(configDir), function(filename) {
         filename = filename.toLowerCase();
         return (
-            !_.startsWith(filename, 'default') && _.endsWith(filename, '.json')
+            !_.startsWith(filename, 'default') && (_.endsWith(filename, '.json') || _.endsWith(filename, '.js'))
         );
     });
 }


### PR DESCRIPTION
Nocto currently successfully loads `local.js` config files (which allows us to reference environment variables from config), but still tries to run the setup wizard as that only accepts `.json` files despite `.js` config files being loaded correctly.